### PR TITLE
Fix Link to CoinHippo Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Connext Bridge is a bridge app built on top of [Connext's nxtp protocol](https:/
   ```
 
 ## Setup your own Bridge Dapp
-We recommend you to use the code from [Bridge | CoinHippo](https://github.com/CoinHippo-Labs/connext-bridge) instead. This is because most UI components and app structures are identical. Besides, the repo has been designed to be built with fewer dependencies while still can take advantage of [Connext's nxtp protocol](https://github.com/connext/nxtp).
+We recommend you to use the code from [Bridge | CoinHippo](https://github.com/CoinHippo-Labs/coinhippo-bridge) instead. This is because most UI components and app structures are identical. Besides, the repo has been designed to be built with fewer dependencies while still can take advantage of [Connext's nxtp protocol](https://github.com/connext/nxtp).


### PR DESCRIPTION
The link in README is intended to redirect to the CoinHippo Bridge from my guessing. Feel free to reject and close this PR if otherwise,