### PR TITLE
supply fee if estimated

### DIFF
--- a/components/bridge/index.js
+++ b/components/bridge/index.js
@@ -1888,6 +1888,7 @@ export default () => {
         callData:
           callData ||
           '0x',
+        relayerFee: fee?.gas ? utils.parseUnits(fee.gas.toString(), 18).toString() : undefined
       }
 
       let failed = false
@@ -2017,7 +2018,7 @@ export default () => {
               xcallParams,
             },
           )
-
+          
           const xcall_request =
             is_wrap_eth ?
               await sdk.nxtpSdkBase


### PR DESCRIPTION
Fixes: https://github.com/connext/nxtp/issues/2832

- Adds the `relayerFee` to the `xcall` if it was estimated

NOTE:
- in production environments, the relayer fee will be required to have the transaction complete
- in staging environments, this will not be enforced